### PR TITLE
change directory separator for linux & windows compability

### DIFF
--- a/SEPA/Factory/XmlGeneratorFactory.php
+++ b/SEPA/Factory/XmlGeneratorFactory.php
@@ -10,12 +10,12 @@ namespace SEPA\Factory;
 
 use SEPA;
 
-require_once 'SEPA\ValidationRules.php';
-require_once 'SEPA\XMLGenerator.php';
-require_once 'SEPA\Message.php';
-require_once 'SEPA\GroupHeader.php';
-require_once 'SEPA\PaymentInfo.php';
-require_once 'SEPA\DirectDebitTransactions.php';
+require_once 'SEPA/ValidationRules.php';
+require_once 'SEPA/XMLGenerator.php';
+require_once 'SEPA/Message.php';
+require_once 'SEPA/GroupHeader.php';
+require_once 'SEPA/PaymentInfo.php';
+require_once 'SEPA/DirectDebitTransactions.php';
 
 class XmlGeneratorFactory {
 

--- a/SEPA/ValidationRules.php
+++ b/SEPA/ValidationRules.php
@@ -33,7 +33,7 @@ namespace SEPA;
 		 * @return mixed
 		 */
 		public function unicodeDecode($string) {
-			\Unidecode::$containing_dir = '/unicode_decode/';
+			\Unidecode::$containing_dir = 'unicode_decode';
 			return \Unidecode::decode($string);
 		}
 

--- a/SepaXmlFile.php
+++ b/SepaXmlFile.php
@@ -1,5 +1,5 @@
 <?php
-require_once 'SEPA\Factory\XmlGeneratorFactory.php';
+require_once 'SEPA/Factory/XmlGeneratorFactory.php';
 
 use \SEPA\Factory\XmlGeneratorFactory AS SEPAXmlGeneratorFactory;
 

--- a/test.php
+++ b/test.php
@@ -1,6 +1,6 @@
 <?php
 require_once 'SepaXmlFile.php';
-require_once 'SEPA\Factory\XmlGeneratorFactory.php';
+require_once 'SEPA/Factory/XmlGeneratorFactory.php';
 $SEPA = new SepaXmlFile();
 
 $SEPA::$_XML_FILES_REPOSITORY = '/xml_files/';


### PR DESCRIPTION
It should work in both OS with '/' separator, with '/' is windows only.

"Unidecode::$containing_dir" from ValidationRules.php generates incorrect path with duplicate slashes, I don't know if it happens in windows.

..thanks for sharing ..it's a very useful library
