### PR TITLE
add missing mandatory tags for OrganisationIdentification and PrivateIde...

### DIFF
--- a/SEPA/GroupHeader.php
+++ b/SEPA/GroupHeader.php
@@ -212,13 +212,16 @@ interface GroupHeaderInterface {
 
 			if ( !empty($this->OrganisationIdentification) ) {
 
-				$id->addChild('OrgId', $this->OrganisationIdentification);
-
+				$concrete_id = $id->addChild('OrgId');
+		        $other = $concrete_id->addChild('Othr');
+		        $other->addChild('Id', $this->OrganisationIdentification);
 			}
 
 			if ( !empty($this->PrivateIdentification) ) {
 
-				$id->addChild('PrvtId', $this->PrivateIdentification);
+				$concrete_id = $id->addChild('PrvtId');
+				$other = $concrete_id->addChild('Othr');
+				$other->addChild('Id', $this->PrivateIdentification);
 			}
 
 			return $groupHeader;


### PR DESCRIPTION
- add missing mandatory tags for OrganisationIdentification and PrivateIdentification

Tags 'OrgId' or 'PrvtId' needs 'Other' and 'Id' tags to put id, examples:

<pre>
....
      <InitgPty>
        <Nm>name</Nm>
    <Id>
          <PrvtId>
            <Othr>
              <Id>ES21001X66668045</Id>
            </Othr>
          </PrvtId>
        </Id>
      </InitgPty>
....
</pre>

...
      <InitgPty>
        <Nm>name</Nm>
    <Id>
          <OrgId>
            <Othr>
              <Id>ES21001X66668045</Id>
            </Othr>
          </OrgId>
        </Id>
      </InitgPty>
...

Thanks!
