### PR TITLE
add scheme name and code to group header + add organization_id/private_i...

### DIFF
--- a/SEPA/GroupHeader.php
+++ b/SEPA/GroupHeader.php
@@ -25,6 +25,12 @@ interface GroupHeaderInterface {
 	class GroupHeader extends Message implements GroupHeaderInterface {
 
 		/**
+		 * Specifies code of the scheme name used.
+		 * @var string
+		 */
+		const SCHEME_NAME_CODE = 'CORE';
+
+		/**
 		 * Point to point reference assigned by the instructing party and sent to the next party in the chain
 		 * to unambiguously identify the message.
 		 * Max35Text
@@ -227,6 +233,11 @@ interface GroupHeaderInterface {
 				$concrete_id = $id->addChild('PrvtId');
 				$other = $concrete_id->addChild('Othr');
 				$other->addChild('Id', $this->PrivateIdentification);
+			}
+
+			if (!empty($this->OrganisationIdentification) || !empty($this->PrivateIdentification)) {
+				$schmeNm = $other->addChild('SchmeNm');
+				$schmeNm->addChild('Cd', self::SCHEME_NAME_CODE);
 			}
 
 			return $groupHeader;

--- a/SepaXmlFile.php
+++ b/SepaXmlFile.php
@@ -286,10 +286,15 @@ class SEPAXmlFile {
 
 					$message = $this->objectToArray($message);
 
+                    if ( !isset($message['group_header']['organisation_id']) ) $message['group_header']['organisation_id'] = null;
+                    if ( !isset($message['group_header']['private_id']) ) $message['group_header']['private_id'] = null;	
+
 					$this->messageObject = SEPAXmlGeneratorFactory::createXMLMessage(
 						SEPAXmlGeneratorFactory::createXMLGroupHeader()
 							->setMessageIdentification($message['message_id'])
 							->setInitiatingPartyName($message['group_header']['company_name'])
+							->setOrganisationIdentification($message['group_header']['organisation_id'])
+							->setPrivateIdentification($message['group_header']['private_id'])
 					);
 				}
 


### PR DESCRIPTION
-add scheme name and code to group header
Some banks needs a structure like this(with tags SchemeNm/Cd with value 'CORE'):
<InitgPty>
        <Nm>nom-presentador</Nm>
        <Id>
          <OrgId>
            <Othr>
              <Id>ZZ00001X11111111</Id>
              <SchmeNm>
                <Cd>CORE</Cd>
              </SchmeNm>
            </Othr>
          </OrgId>
        </Id>
</InitgPty>

-add organization_id/private_id init array
'group_header' => array(
            'company_name' => 'Amazing SRL ȘȚțș ыаывпавпва '
            'organisation_id'  => 'id_X' // or 'private_id' => 'id_Y'
),
