### PR TITLE
Fixed type error causing crash on HHVM

### DIFF
--- a/lib/SEPA/Message.php
+++ b/lib/SEPA/Message.php
@@ -162,7 +162,7 @@ class Message extends XMLGenerator implements MessageInterface {
 
 		$this->simpleXmlAppend($this->message, $this->getMessageGroupHeader()->getSimpleXmlGroupHeader());
 
-		foreach (dom_import_simplexml($this->storeXmlPaymentsInfo)->childNodes as $element) {
+		foreach ($this->storeXmlPaymentsInfo->children() as $element) {
 
 			$this->simpleXmlAppend($this->message, $element);
 		}


### PR DESCRIPTION
HHVM's dom_import_simplexml() enforces type restriction by accepting only a SimpleXMLElement, and throwing error otherwise. I guess regular PHP would accept a DOMElement with, possibly, a warning.

This removes the previous conversion so the argument passed to dom_import_simplexml() in XMLGenerator is a propper SimpleXMLElement.