### PR TITLE
Add support for UltimateCreditor's SIRET number

### DIFF
--- a/lib/SEPA/PaymentInfo.php
+++ b/lib/SEPA/PaymentInfo.php
@@ -161,6 +161,12 @@ interface PaymentInfoInterface {
 		private $ultimateCreditor = '';
 
 		/**
+		 * This property is optional
+		 * @var string
+		 */
+		private $ultimateCreditorSIRET = '';
+
+		/**
 		 * @var bool
 		 */
 		private $useProprietary = true;
@@ -544,11 +550,30 @@ interface PaymentInfoInterface {
 		}
 
 		/**
+		 * This property is optional
+		 * @param $UltimateCreditorSIRET
+		 * @return $this
+		 */
+		public function setUltimateCreditorSIRET($UltimateCreditorSIRET) {
+
+			$this->ultimateCreditorSIRET = $UltimateCreditorSIRET;
+			return $this;
+		}
+
+		/**
 		 * @return string
 		 */
 		public function getUltimateCreditor() {
 
 			return $this->ultimateCreditor;
+		}
+
+		/**
+		 * @return string
+		 */
+		public function getUltimateCreditorSIRET() {
+
+			return $this->ultimateCreditorSIRET;
 		}
 
 		/**
@@ -911,8 +936,16 @@ interface PaymentInfoInterface {
 
             //UltimateCreditor optional
             if ( !empty($this->UltimateCreditor) ) {
-
-                $paymentInfo->addChild('UltmtCdtr', $this->getUltimateCreditor());
+				//UltimateCreditorSIRET optional
+				if ( !empty($this->UltimateCreditorSIRET) ) {
+					$ultimateCreditor = $paymentInfo->addChild('UltmtCdtr');
+					$ultimateCreditor->addChild('Nm', $this->getUltimateCreditor());
+					$ultimateCreditorOthr = $ultimateCreditor->addChild('Id')->addChild('OrgId')->addChild('Othr');
+					$ultimateCreditorOthr->addChild('Id', $this->getUltimateCreditorSIRET());
+					$ultimateCreditorOthr->addChild('SchmeNm')->addChild('Prtry', 'SIRET');
+				} else {
+					$paymentInfo->addChild('UltmtCdtr', $this->getUltimateCreditor());
+				}
             }
 
             $paymentInfo->addChild('ChrgBr', self::CHARGE_BEARER);


### PR DESCRIPTION
Hi !

First, thanks a lot for your library that is perfect :)

I implemented a small patch to associate a SIRET number (official identifier for French companies) to an UltimateCreditor. It's required in some transactions with French banks.

Please could you merge it ?

Thanks :)