### PR TITLE
Sanitize strings before checking length.

### DIFF
--- a/lib/SEPA/CreditTransferTransactions.php
+++ b/lib/SEPA/CreditTransferTransactions.php
@@ -178,6 +178,8 @@ class CreditTransferTransaction extends PaymentInfo implements TransactionInterf
      * @throws \Exception
      */
     public function setCreditInvoice($invoice) {
+        $invoice = $this->unicodeDecode($invoice);
+
         if ( !$this->checkStringLength($invoice, 140) ) {
 
             throw new \Exception(ERROR_MSG_DD_INVOICE_NUMBER . $this->getInstructionIdentification());
@@ -201,6 +203,8 @@ class CreditTransferTransaction extends PaymentInfo implements TransactionInterf
      * @throws \Exception
      */
     public function setCreditorName($name) {
+        $name = $this->unicodeDecode($name);
+
         if ( !$this->checkStringLength($name, 70) ) {
 
             throw new \Exception(ERROR_MSG_DD_NAME . $this->getInstructionIdentification());

--- a/lib/SEPA/DirectDebitTransactions.php
+++ b/lib/SEPA/DirectDebitTransactions.php
@@ -225,6 +225,8 @@ class DirectDebitTransaction extends PaymentInfo implements TransactionInterface
 	 * @throws \Exception
 	 */
 	public function setDebtorName($name) {
+		$name = $this->unicodeDecode($name);
+
 		if ( !$this->checkStringLength($name, 140) ) {
 
 			throw new \Exception(ERROR_MSG_DD_NAME . $this->getInstructionIdentification());
@@ -258,6 +260,8 @@ class DirectDebitTransaction extends PaymentInfo implements TransactionInterface
 	 * @throws \Exception
 	 */
 	public function setDirectDebitInvoice($invoice) {
+		$invoice = $this->unicodeDecode($invoice);
+
 		if ( !$this->checkStringLength($invoice, 140) ) {
 
 			throw new \Exception(ERROR_MSG_DD_INVOICE_NUMBER . $this->getInstructionIdentification());

--- a/lib/SEPA/GroupHeader.php
+++ b/lib/SEPA/GroupHeader.php
@@ -92,6 +92,8 @@ class GroupHeader extends Message implements GroupHeaderInterface {
 	 * @throws \Exception
 	 */
 	public function setMessageIdentification($msgId) {
+		$msgId = $this->unicodeDecode($msgId);
+
 		if ( !$this->checkStringLength($msgId, 35) ) {
 			throw new \Exception(ERROR_MSG_MESSAGE_IDENTIFICATION);
 		}
@@ -168,6 +170,8 @@ class GroupHeader extends Message implements GroupHeaderInterface {
 	}
 
 	public function setAddressLine($name) {
+		$name = $this->unicodeDecode($name);
+
 		if ( !$this->checkStringLength($name, 140)) {
 
 			throw new \Exception(ERROR_MSG_INITIATING_PARTY_NAME);
@@ -180,6 +184,8 @@ class GroupHeader extends Message implements GroupHeaderInterface {
 
 
 	public function setCountry($name) {
+		$name = $this->unicodeDecode($name);
+
 		if ( !$this->checkStringLength($name, 140)) {
 
 			throw new \Exception(ERROR_MSG_INITIATING_PARTY_NAME);

--- a/lib/SEPA/PaymentInfo.php
+++ b/lib/SEPA/PaymentInfo.php
@@ -275,6 +275,7 @@ interface PaymentInfoInterface {
 		 * @throws \Exception
 		 */
 		public function setPaymentInformationIdentification($paymentInformationId) {
+			$paymentInformationId = $this->unicodeDecode($paymentInformationId);
 
 			if ( !$this->checkStringLength($paymentInformationId, 35) ) {
 


### PR DESCRIPTION
Add some calls to unicodeDecode() to sanitize strings on:

- CreditTransferTransactions->setCreditInvoice($invoice)
- CreditTransferTransactions->setCreditorName($name)
- DirectDebitTransactions->setDebtorName($name)
- DirectDebitTransactions->setDirectDebitInvoice($invoice)
- GroupHeader->setMessageIdentification($msgId)
- GroupHeader->setAddressLine($name)
- GroupHeader->setCountry($name)
- PaymentInfo->setPaymentInformationIdentification($paymentInformationId)

