### PR TITLE
add potentially non-standard php extensions to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,8 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"require": {
-		"php": ">=5.6"
+		"php": ">=5.6",
+		"ext-bcmath": "*",
+		"ext-mbstring": "*"
 	}
 }


### PR DESCRIPTION
upon installing this to GCP I hit a build failure, composer can enforce the environment is setup correctly, but it needs to be told which extensions are required.

Omitting some of the required extensions as they're "standard"

```
php phpcompatinfo-5.0.12.phar analyser:run .
Extensions Analysis

    Extension  Matches REF       EXT min/Max PHP min/Max PHP all 
    Core               Core      5.3.0       5.3.0               
    SimpleXML          SimpleXML 5.0.1       5.0.1               
    bcmath             bcmath    4.0.0       4.0.0               
    date               date      5.2.0       5.2.0               
    dom                dom       5.0.0       5.0.0               
    gmp                gmp       4.0.4       4.0.4               
    json               json      5.2.0       5.2.0               
    libxml             libxml    5.1.0       5.1.0               
    mbstring           mbstring  4.0.6       4.0.6               
    pcre               pcre      4.0.5       4.0.5               
    spl                spl       5.1.0       5.1.0               
    standard           standard  5.0.0       5.0.0               
    Total [12]        
```