### PR TITLE
Fix error in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		    "cmpayments/iban": "^1.1"
     },
 	"require-dev": {
-		"phpunit/phpunit": "^8.3"
+		"phpunit/phpunit": "^8.3",
 		"ext-bcmath": "*",
 		"ext-mbstring": "*"
 	}


### PR DESCRIPTION
There's a missing trailing comma in composer.json that prevents installing the package.

```
Parse error on line 27:
.../phpunit": "^8.3"		"ext-bcmath": "*",
---------------------^
Expected one of: 'EOF', '}', ':', ',', ']'
```


This PR fix it.