### PR TITLE
Fix deprecated messages on php8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		    "cmpayments/iban": "^1.1"
     },
 	"require-dev": {
-		"phpunit/phpunit": "^8.3"
+		"phpunit/phpunit": "^8.3",
 		"ext-bcmath": "*",
 		"ext-mbstring": "*"
 	}

--- a/src/PaymentInfo.php
+++ b/src/PaymentInfo.php
@@ -507,7 +507,7 @@ class PaymentInfo extends Message implements PaymentInfoInterface
         if (empty($creditorSchemaId) || is_null($creditorSchemaId)) {
             throw new \Exception(ERROR_MSG_PM_CREDITOR_SCHEME_IDENTIFICATION);
         }
-        $this->CreditorSchemeIdentification = $creditorSchemaId;
+        $this->creditorSchemeIdentification = $creditorSchemaId;
         return $this;
     }
 
@@ -943,8 +943,8 @@ class PaymentInfo extends Message implements PaymentInfoInterface
         $privateIdentification = $creditorSchemeIdentificationID->addChild('PrvtId');
         $othr = $privateIdentification->addChild('Othr');
 
-        if (!empty($this->CreditorSchemeIdentification)) {
-            $othr->addChild('Id', $this->CreditorSchemeIdentification);
+        if (!empty($this->creditorSchemeIdentification)) {
+            $othr->addChild('Id', $this->creditorSchemeIdentification);
         }
 
         $schemeName = $othr->addChild('SchmeNm');

--- a/src/ValidationRules.php
+++ b/src/ValidationRules.php
@@ -131,7 +131,7 @@ class ValidationRules implements Validation
      * @return bool
      * @throws \Exception
      */
-    public function validation($xmlSEPAFile = null, $xsdPainRule)
+    public function validation($xmlSEPAFile, $xsdPainRule)
     {
         if (empty($xmlSEPAFile) && !file_exists($xmlSEPAFile)) {
             throw new \InvalidArgumentException('Missing SEPA XML File');


### PR DESCRIPTION
$xmlSEPAFile parameter of "validation" function should be required instead of optional (with a default value of null). Also fixed case of CreditorSchemeIdentification property.