### PR TITLE
CMPayments\IBAN::validate argument is an optional output argument.

### DIFF
--- a/src/ValidationRules.php
+++ b/src/ValidationRules.php
@@ -47,7 +47,7 @@ class ValidationRules implements Validation
     public function checkIBAN($value)
     {
         $iban = new IBAN($value);
-        return $iban->validate($value);
+        return $iban->validate();
     }
 
     /**


### PR DESCRIPTION
You don't need to pass a value to CMPayments\IBAN::validate if you don't use it later.